### PR TITLE
Remove unnecessary devDep `eslint-config-prettier`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,6 @@ module.exports = {
 		"plugin:react/recommended",
 		"plugin:react/jsx-runtime",
 		"plugin:react-hooks/recommended",
-		"prettier",
 	],
 	ignorePatterns: ["dist", ".eslintrc.cjs"],
 	parserOptions: { ecmaVersion: "latest", sourceType: "module" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 				"@vitejs/plugin-react": "4.3.0",
 				"date-fns": "3.6.0",
 				"eslint": "8.56.0",
-				"eslint-config-prettier": "9.1.0",
 				"eslint-plugin-react": "7.34.2",
 				"eslint-plugin-react-hooks": "4.6.2",
 				"eslint-plugin-react-refresh": "0.4.18",
@@ -2399,18 +2398,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-config-prettier": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-			"dev": true,
-			"bin": {
-				"eslint-config-prettier": "bin/cli.js"
-			},
-			"peerDependencies": {
-				"eslint": ">=7.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"@vitejs/plugin-react": "4.3.0",
 		"date-fns": "3.6.0",
 		"eslint": "8.56.0",
-		"eslint-config-prettier": "9.1.0",
 		"eslint-plugin-react": "7.34.2",
 		"eslint-plugin-react-hooks": "4.6.2",
 		"eslint-plugin-react-refresh": "0.4.18",


### PR DESCRIPTION
Formatting rules are deprecated since ESLint v8.53.0.

Info:
- https://github.com/eslint/eslint/releases/tag/v8.53.0
- https://eslint.org/blog/2023/10/deprecating-formatting-rules

Sync from:
https://github.com/germanfrelo/template/pull/28/commits/608c9ecc360004e8236f9240780cfea0e7ba3f68